### PR TITLE
GSS 143 beta5 test fixes

### DIFF
--- a/workspace/plan/beta5-buglist.md
+++ b/workspace/plan/beta5-buglist.md
@@ -2,37 +2,40 @@
 
 ##  Sept 2024 GSS #143
 
-[ ] CTF - balancing teams was off - choose team?
-[ ] CTF - scoreboard adjusting? First connection was off.
-[ ] CTF - Add what team am im on on HUD.
-[ ] Prop hunt - black out on HUD hunter
-[ ] Prop hunt - every shot takes away health from hunter
-[ ] Prop hunt - disable automelee
-[ ] Prop hunt - disable flips and stuff for prophunt
-[ ] Prop hunt - No damage on hiding time
-[ ] Prop hunt - disable lifebar on prop
-[ ] Raise ricochet mutator up to eye level
-[ ] Invisible mutator not working?
-[ ] Mutator perm after map
-[ ] Shut off acro on command menu
-[ ] invalid index of edict crashes?
-[ ] Should not throw explosive weapon in gungame
-[ ] Gungame - shut off barrel mutator
-[ ] Interupt taunts without health credit
-[ ] Shut off mp_timelimit in gungame. Timer was still showing?
+[ ] glock and chaingun ironsight disabled
+[ ] Interrupt taunts without health credit
+[ ] Lose invinicibily on attack 
+---
 [ ] Idea - Broken mouse mutator
-[ ] Gungame - No rounds, end game on win.
-[ ] When nooclip mutator ends, respawn
-[x] Snowballs gamemode list update was wrong title?
-[ ] Idea: asmr weapon for UT
-[ ] Inverse forward and back for mirror mutator
-[ ] Recoil mutator?
-[ ] Hornets too slow when firing head of th eplayer
-[ ] Make messages reliable
-[ ] Draw attention to voted items on HUD.
-[ ] Friend fire on busting?
-[ ] Loose invinicibily on attack 
-[ ] "Dealter" under gun
-[ ] Skulls floating, fix pick up problem
-[ ] Farts in chilldemic may kill teammate?
 [ ] Bird to fix canyon?
+[ ] ASMR weapon from UT?
+[ ] Recoil mutator?
+---
+[x] Make messages reliable
+[x] Invisible mutator not working?
+[x] Mutator perm after map
+[x] When noclip mutator ends, respawn
+[x] CTF - balancing teams was off - choose team?
+[x] CTF - Add what team am im on HUD.
+[x] CTF - scoreboard adjusting? First connection was off.
+[x] Prop hunt - black out on HUD hunter
+[x] Prop hunt - every shot takes away health from hunter
+[x] Prop hunt - disable automelee
+[x] Prop hunt - disable flips and stuff for prophunt
+[x] Prop hunt - No damage on hiding time
+[x] Prop hunt - disable lifebar on prop
+[x] Raise ricochet mutator up to eye level
+[x] Shut off acro on command menu
+[ ] invalid index of edict crashes?
+[x] Gungame - Should not throw explosive weapon
+[x] Gungame - shut off barrel mutator
+[x] Gungame - Shut off mp_timelimit. Timer was still showing?
+[x] Gungame - No rounds, end game on win.
+[x] Snowballs gamemode list update was wrong title?
+[x] Inverse forward and back for mirror mutator
+[x] Hornets too slow when firing head of th eplayer
+[x] Draw attention to voted items on HUD.
+[x] Friendly fire on busting?
+[x] "Dealter" under gun
+[x] Skulls floating, fix pick up problem
+[x] Farts in chilldemic may kill teammate?

--- a/workspace/redist/commandmenu.txt
+++ b/workspace/redist/commandmenu.txt
@@ -63,6 +63,11 @@
         "1" "On" "cl_aws 1"
         "2" "Off" "cl_aws 0"
     }
+    "6" "Keyboard Acrobatics"
+    {
+        "1" "On" "cl_kacro 1"
+        "2" "Off" "cl_karco 0"
+    }
 }
 "2" "HUD"
 {

--- a/workspace/redist/readme.txt
+++ b/workspace/redist/readme.txt
@@ -47,6 +47,7 @@ Beta 5 Features:
     - Freezegun does not freeze its owner
     - Reduced freezegun speed and power
     - Improved rocketcrowbar rocket launching
+    - Fix hornetgun velocity while running
 - Soundtrack
     - Includes 14 new tracks, each map plays a set track
 - Map Changes
@@ -87,12 +88,13 @@ Beta 5 Features:
         - "napkinstory" - the legend reduced to two words
     - Gamemode Changes
         - Show game rules on connection
-        - Disable randomweapons mutator from gungame
+        - Disable numerous Mutators from gungame
         - Disable numerous mutators from snowball game mode
         - Tweaked game mode waiting times
         - Show lives in battle royale
         - Show persons who are in arena mode on scoreboard
         - Improved objectives in JVS
+        - Gungame is now roundless
     - Mutator Changes
         - Mutators are independent timers
         - Changed "sv_mutators" to "sv_addmutator"
@@ -136,6 +138,7 @@ Beta 5 Features:
     - Added "cl_crosshairammo [0|1]" to show ammo status in crosshairs
     - Added headshot indicator in death notice
     - Added default keyboard layout and command menu items
+    - Vote menu highlights selected items
 - Server
     - Added "mp_ctfspawn1" and "mp_ctfspawn2" where flagbases will spawn
     - "vote" command now case insensitive


### PR DESCRIPTION
- Dealter farts are discernable when fired
- Support mutators without a timelimit
- Include forward and back mirror mutator
- Prop hunt fixes including removal of lifebar, hunters life and fade
- Make selected vote options apparent
- Turn off Busters friendly fire
- Fix cold skull drops
- Fix hornet fire velocity
- Fix gungame timelimit, make it roundless
- Fix invisible mutator, add Shidden title
- Raise ricochet disc to eye level
- CTF fixes, team balance and print outs
- Place players in spawn spots after noclip ends