### PR TITLE
Beta 5 Test 1 fixes

### DIFF
--- a/workspace/plan/beta5-buglist.md
+++ b/workspace/plan/beta5-buglist.md
@@ -1,14 +1,54 @@
 ## New Recommendations
 
+## December 2024 Test #1
+
+[ ] doublefrost player spawn points and func_wall
+[ ] vested mutator not giving vest
+[x] ctf frag on game end?
+[x] prophunt model spin fix?
+    [x] fix invisible model index
+[x] skeletons should not pick up weapons
+    [x] melee only
+    [x] remove flames on skeleton in view.
+        [x] make sure skeleton icon shows
+[x] strip weapons at end of horde
+[x] capture the chumtoad - use score
+    [x] dont shoot in ctc, only hurt chumtoad dude
+    [x] farts can kill other if havign chumtoad
+[x] pull skulls out of walls
+[x] fix flat grenade model
+[x] with auto taunt on, stop taunt on death
+[x] smoke on sawed off too much
+[x] flamethrower close up fix
+[x] ctf score keeps disappearing after spawn?
+    [ ] ctf score board not ordered on wins or frags -- maybe deaths?
+[x] cancel taunt on weapon change?
+[x] Stop coldspot from moving when game is over
+[x] fixed disc angle, path, and angles
+---
+[x] vice during god mutator
+[x] improve random vote if deadlocked
+[x] improve mutator vote visualization
+[x] improve pushy mutator behavior
+[x] instant decap on ricochet head hit
+[x] auto decap on ricochet hit in head
+---
+[ ] sky texture on spawn monsters
+[ ] accept all cookies mutator
+[ ] blue screen mutator
+---
+
+
 ##  Sept 2024 GSS #143
 
-[ ] Interrupt taunts without health credit
-[ ] Lose invinicibily on attack 
+[ ] Lose invinicibily on attack
+[ ] invalid index of edict crashes?
 ---
 [ ] Idea - Broken mouse mutator
 [ ] ASMR weapon from UT?
 [ ] Recoil mutator?
 ---
+[x] Interrupt taunts without health credit
 [x] Bird to fix canyon?
 [x] glock and chaingun ironsight disabled
 [x] Make messages reliable
@@ -26,7 +66,6 @@
 [x] Prop hunt - disable lifebar on prop
 [x] Raise ricochet mutator up to eye level
 [x] Shut off acro on command menu
-[ ] invalid index of edict crashes?
 [x] Gungame - Should not throw explosive weapon
 [x] Gungame - shut off barrel mutator
 [x] Gungame - Shut off mp_timelimit. Timer was still showing?

--- a/workspace/redist/readme.txt
+++ b/workspace/redist/readme.txt
@@ -58,6 +58,10 @@ Beta 5 Features:
     - Remove fragged player models after round ends
     - No credits for airstrike in gungame
     - Game_equip entity disabled for certain gameplay modes
+    - Disable dontshoot in Capture the Chumtoad
+    - Enable score points in Capture the Chumtoad
+    - Remove pink flame from self skeleton in Chilldemic
+    - Limit weapons available to skeletons in Chilldemic
 - 24 New Mutators - supports combination and randomly selected (sv_mutators)
     - "toilet" - we aint hurt nobody
     - "jeepathon" - now available at your local Jeep Wrangler dealership
@@ -103,6 +107,7 @@ Beta 5 Features:
     - Egon and snowball pushy mutator fixed
     - Bots no longer vote for filtered mutators
     - Improved sanic sprites by fading after death
+    - Soften pushy, enable on ground
 - Third Function Weapon Support
     - Via the reload button
         - Knife
@@ -216,6 +221,7 @@ Beta 5 Features:
     - Remove rune from all spectators
     - Fix crash involving monster projectiles
     - Fixed sys_timescale in latest engine, including linux
+    - Improved deadlock vote tie-breaker, visual of mutator voting
 
 Beta 4 Features:
 


### PR DESCRIPTION
[x] ctf frag on game end?
[x] prophunt model spin fix?
    [x] fix invisible model index
[x] skeletons should not pick up weapons
    [x] melee only
    [x] remove flames on skeleton in view.
        [x] make sure skeleton icon shows
[x] strip weapons at end of horde
[x] capture the chumtoad - use score
    [x] dont shoot in ctc, only hurt chumtoad dude
    [x] farts can kill other if havign chumtoad
[x] pull skulls out of walls
[x] fix flat grenade model
[x] with auto taunt on, stop taunt on death
[x] smoke on sawed off too much
[x] flamethrower close up fix
[x] ctf score keeps disappearing after spawn?
[x] cancel taunt on weapon change?
[x] Stop coldspot from moving when game is over
[x] fixed disc angle, path, and angles
---
[x] vice during god mutator
[x] improve random vote if deadlocked
[x] improve mutator vote visualization
[x] improve pushy mutator behavior
[x] instant decap on ricochet head hit
[x] auto decap on ricochet hit in head