### PR TITLE
GSS Playtest Fixes from Jan 2025

### DIFF
--- a/workspace/plan/beta5-buglist.md
+++ b/workspace/plan/beta5-buglist.md
@@ -1,5 +1,17 @@
 ## New Recommendations
 
+## Janurary 2025 GSS Test
+
+[ ] vote on ctf was wrong
+[x] round 2 gungame fix?
+[x] no drowning in prophunt as prop
+[x] mini slide problem
+[x] no winners in horde mode
+    [x] improve winning scores
+[x] add weapon tilt calculation in zapper mode
+[x] crash in 1 on 1 when bot is kicked
+[x] fix dualhornet gun config text
+
 ## December 2024 Test #2
 
 [ ] check height of enemy to step down?

--- a/workspace/plan/learnings.md
+++ b/workspace/plan/learnings.md
@@ -425,3 +425,4 @@ A core file can be reloaded and [read later in gdb](https://stackoverflow.com/qu
 1. [What follows](https://javagl.github.io/GLConstantsTranslator/GLConstantsTranslator.html) is a great library of constants for GL rendering.
 1. A hack for pushing an entity (or player) on the ground is to set `pOther->pev->flags &= ~FL_ONGROUND;` temproarily, and then in its `prethink`, set the desired velocity.
 1. To clear decals, use the `for ( int x = 0; x < (int)CVAR_GET_FLOAT( "r_decals" ); x++ ) gEngfuncs.pEfxAPI->R_DecalRemoveAll ( x );` on the client size.
+1. Using Vmware Fusion, if the mouse is behavioring poorly, use the config value `mks.gamingMouse.policy = "gaming"` in the vmx config file. See this [thread](https://www.reddit.com/r/vmware/comments/p0x7yy/with_vmware_tools_how_to_keep_the_mouse_grabbed/)

--- a/workspace/redist/gfx/shell/kb_act.lst
+++ b/workspace/redist/gfx/shell/kb_act.lst
@@ -112,7 +112,7 @@
 "blank"			"#Ice_Weapon_Category_7"
 "blank"			"=========================="
 "use weapon_dual_chaingun"		"#Ice_DualChaingun"
-"use weapon_dual_hornetgun"		"#Ice_DualHortnetgun"
+"use weapon_dual_hornetgun"		"#Ice_DualHornetgun"
 "use weapon_dual_railgun"		"#Ice_DualRailgun"
 "use weapon_dual_rpg"			"#Ice_DualRpg"
 "use weapon_dual_flamethrower"	"#Ice_DualFlameThrower"

--- a/workspace/redist/readme.txt
+++ b/workspace/redist/readme.txt
@@ -22,8 +22,16 @@ Beta 6 Features:
     - Kicked bots do not rejoin game
     - Gameplay
         - Players who spectate during round do not count
+        - Patch game crash when bot is kicked from the server during arena
+        - Fix gungame winner printout
+        - Never drown as a prop
+        - Normalize determine winner calculations, and include tie wins
+        - Remove difficult to understand jvs damage rule
+    - Mutators
+        - Do not duck in minime mode during selaco slide
     - Weapons
         - Nuke camera is reset properly
+        - Remove zapgun punch angles
 
 Beta 5 Features:
 


### PR DESCRIPTION
- Remove zapgun punch angles
- Patch game crash when bot is kicked from the server during arena
- Fix gungame winner printout
- Do not duck in minime mode during selaco slide
- Never drown as a prop
- Normalize determine winner calculations, and include tie wins
- Remove difficult to understand jvs damage rule