### PR TITLE
More gss playtest jan 2025 patches

### DIFF
--- a/workspace/plan/roadmap.md
+++ b/workspace/plan/roadmap.md
@@ -93,6 +93,10 @@ To faithfully recreate the Cold Ice 1.75 experience that works in Half-Life Gold
     1. [x] LMS
         1. [x] with team support
         1. [x] Shrinking safe zone pinned to info_player_start
+1. Game Mechanics
+    1. [ ] Combo meter for hits applied without taking damage
+1. Mutators
+    1. [ ] Boom Kick [seen in cruel](https://www.youtube.com/watch?v=5zpBkubVhtw)
 1. Player Models
     1. [ ] Vanilla Ice
 
@@ -220,6 +224,8 @@ To faithfully recreate the Cold Ice 1.75 experience that works in Half-Life Gold
     1. [ ] New Life Launcher program?
     1. [ ] [Inno Setup](https://github.com/N7P0L3ON/Flatline-Arena-Master/commit/5158ce7977d7a0a5ba5ff9bc2d6dcce5350b1697) install script
 1. Game Modes
+    1. [ ] One of those beeing Hide and Seek -> one player gets invisibility that he can use to move around the map, the rest are trying to find and kill him. While moving he's partially visible, while not moving he's invisible. The invisible player gets points every 30 seconds he's not taking damage. The invisible player has no weapons and cannot pick up weapons. If round rules are in effect if the round finishes, the alive invisible player gets a reward.
+        [ ] The invisible player only gets slappers / back attack
     1. [ ] [Clear decals](https://github.com/N7P0L3ON/flatline-24-default/commit/a4dcc8c435ce574ec5ed842e23ffe4c570001fd5), and recharge hev/health charges on round.
     1. [ ] Horde mode improvements
         1. [ ] Amount of emenies increase from 5 to 10

--- a/workspace/redist/delta.lst
+++ b/workspace/redist/delta.lst
@@ -253,7 +253,7 @@ weapon_data_t none
 	DEFINE_DELTA( m_fAimedDamage, DT_FLOAT, 6, 0.1 ),
 	DEFINE_DELTA( m_fInZoom, DT_INTEGER, 1, 1.0 ),
 	DEFINE_DELTA( m_iWeaponState, DT_INTEGER, 2, 1.0 ),
-	DEFINE_DELTA( m_iId, DT_INTEGER, 5, 1.0 ),
+	DEFINE_DELTA( m_iId, DT_INTEGER, 10, 1.0 ),
 	DEFINE_DELTA( iuser1, DT_SIGNED | DT_INTEGER, 10, 1.0  ),
 	DEFINE_DELTA( iuser2, DT_SIGNED | DT_INTEGER, 10, 1.0  ),
 	DEFINE_DELTA( iuser3, DT_SIGNED | DT_INTEGER, 10, 1.0  ),

--- a/workspace/redist/readme.txt
+++ b/workspace/redist/readme.txt
@@ -15,6 +15,7 @@ Beta 6 Features:
     - Battle Royale offers team based play with safe area
         - Added mp_royaleteam [0|1] for teamplay option
     - Round based games remove decals and items when round is over
+    - Added Gungame level to the scoreboard
 - Bots
     - When sv_defaultbots is set to 0, all bots are kicked
 - Fixes
@@ -23,15 +24,19 @@ Beta 6 Features:
     - Gameplay
         - Players who spectate during round do not count
         - Patch game crash when bot is kicked from the server during arena
-        - Fix gungame winner printout
         - Never drown as a prop
         - Normalize determine winner calculations, and include tie wins
         - Remove difficult to understand jvs damage rule
+        - Gungame
+            - Fix empty scoreboard during Gungame
+            - Fix Gungame winner printout
     - Mutators
         - Do not duck in minime mode during selaco slide
     - Weapons
         - Nuke camera is reset properly
         - Remove zapgun punch angles
+    - Game Mechanics
+        - Patched flying with spamming frontflip
 
 Beta 5 Features:
 


### PR DESCRIPTION
- Add ricochet label, fix noreload label, support multiple mutator
- Fix items, ammo damage behavior, do not respawn all, and remove runes
- Fix "spectator" in capture the chumtoad mode
- Patch spamming the front flip button.
- Fix empty scoreboard during gungame
- Move gungame levels to scoreboard
- Support 0 indexed weapons